### PR TITLE
fix problem when only VS2017 installed

### DIFF
--- a/nuget/AspectInjector.Package/build/AspectInjector.targets
+++ b/nuget/AspectInjector.Package/build/AspectInjector.targets
@@ -45,7 +45,7 @@
       <SnToolsRaw>@(SnTools)</SnToolsRaw>
     </PropertyGroup>
     <PropertyGroup>
-      <SnTool>$(SnToolsRaw.Substring(0, $(SnToolsRaw.IndexOf(';'))))</SnTool>
+      <SnTool>$(SnToolsRaw.Split(';')[0])</SnTool>
     </PropertyGroup>
   </Target>
 


### PR DESCRIPTION
If user only installed VS2017 the SnToolsRaw will has only one Value with no ';'.
So SnToolsRaw.Substring(0, $(SnToolsRaw.IndexOf(';'))) will failed cause SnToolsRaw.Substring(0, -1) .
Different from Substring + IndexOf. Split will return the whole string. 
And it's almost same in any other situation.
So I would like to change it to Split(';')[0]