### PR TITLE
#144 Cache scoped items

### DIFF
--- a/samples/src/Cache/CacheAspect.cs
+++ b/samples/src/Cache/CacheAspect.cs
@@ -74,9 +74,7 @@ namespace Aspects.Cache
 
             if (!resultFound)
             {
-                result = target(args);
-                if (result == null)
-                    result = NullMarker;
+                result = target(args) ?? NullMarker;
 
                 foreach (var cache in cacheTriggers)
                     cache.Cache.Set(key, result, cache.Policy);

--- a/samples/src/Cache/CacheAspect.cs
+++ b/samples/src/Cache/CacheAspect.cs
@@ -86,9 +86,9 @@ namespace Aspects.Cache
         }
 
         protected string GetKey(MethodInfo method, IEnumerable<object> args) =>
-            $"{method.DeclaringType.FullName.GetHashCode()}-{string.Join("-", args.Select(a => a.GetHashCode()))}";
+            $"{method.GetHashCode()}-{string.Join("-", args.Select(a => a.GetHashCode()))}";
 
         protected string GetKey(object instance, MethodInfo method, IEnumerable<object> args) =>
-            $"{instance.GetHashCode()}-{method.DeclaringType.FullName.GetHashCode()}-{string.Join("-", args.Select(a => a.GetHashCode()))}";
+            $"{instance.GetHashCode()}-{method.GetHashCode()}-{string.Join("-", args.Select(a => a.GetHashCode()))}";
     }
 }

--- a/samples/tests/Aspests.Tests/CacheTests.cs
+++ b/samples/tests/Aspests.Tests/CacheTests.cs
@@ -9,7 +9,7 @@ namespace Aspests.Tests
 {
     public class CacheTests
     {
-        class TestCalss
+        class TestClass
         {
             [MemoryCache(3)]
             public void Do(ref int a)
@@ -52,7 +52,7 @@ namespace Aspests.Tests
         [Fact]
         public async Task Cache_Aspect_Caches_Method_Result()
         {
-            var target = new TestCalss();
+            var target = new TestClass();
             var expected = target.Calculate(10, "test");
             await Task.Delay(10);
             var result = target.Calculate(10, "test");
@@ -72,27 +72,27 @@ namespace Aspests.Tests
         [Fact]
         public async Task Cache_Aspect_Distinct_Instances()
         {
-            var target = new TestCalss();
-            var target2 = new TestCalss();
+            var target = new TestClass();
+            var target2 = new TestClass();
             var result1 = target.Calculate(20, "test");
             await Task.Delay(10);
             var result2 = target2.Calculate(20, "test");
 
-            Assert.NotEqual(result1, result2);
+            Assert.Equal(result1, result2);
         }
 
         [Fact]
         public async Task Cache_Aspect_Caches_Static_Method_Result()
         {
-            var expected = TestCalss.CalculateStatic(30, "test");
+            var expected = TestClass.CalculateStatic(30, "test");
             await Task.Delay(10);
-            var result = TestCalss.CalculateStatic(30, "test");
+            var result = TestClass.CalculateStatic(30, "test");
             await Task.Delay(10);
-            var result2 = TestCalss.CalculateStatic(301, "test1");
+            var result2 = TestClass.CalculateStatic(301, "test1");
             await Task.Delay(10);
-            var result3 = TestCalss.CalculateStatic(30, "test");
+            var result3 = TestClass.CalculateStatic(30, "test");
             await Task.Delay(3000);
-            var result4 = TestCalss.CalculateStatic(30, "test");
+            var result4 = TestClass.CalculateStatic(30, "test");
 
             Assert.Equal(expected, result);
             Assert.Equal(expected, result3);
@@ -103,7 +103,7 @@ namespace Aspests.Tests
         [Fact]
         public async Task Cache_Aspect_Caches_TaskMethod_Result()
         {
-            var target = new TestCalss();
+            var target = new TestClass();
             var expected = await target.CalculateTask(40, "test");
             await Task.Delay(10);
             var result = await target.CalculateTask(40, "test");
@@ -123,7 +123,7 @@ namespace Aspests.Tests
         [Fact]
         public async Task Cache_Aspect_Caches_AsyncTaskMethod_Result()
         {
-            var target = new TestCalss();
+            var target = new TestClass();
             var expected = await target.CalculateTaskAsync(50, "test");
             await Task.Delay(10);
             var result = await target.CalculateTaskAsync(50, "test");
@@ -143,7 +143,7 @@ namespace Aspests.Tests
         [Fact]
         public void Cache_Void_Method()
         {
-            var target = new TestCalss();
+            var target = new TestClass();
             var a = 1;
             target.Do(ref a);
             Assert.Equal(2, a);
@@ -156,7 +156,7 @@ namespace Aspests.Tests
         [Fact]
         public async Task Cache_TaskVoid_Method()
         {
-            var target = new TestCalss();
+            var target = new TestClass();
             var a = 1;
             await target.DoTask(ref a);
             Assert.Equal(2, a);

--- a/samples/tests/Aspests.Tests/CacheTests.cs
+++ b/samples/tests/Aspests.Tests/CacheTests.cs
@@ -31,6 +31,12 @@ namespace Aspests.Tests
             }
 
             [MemoryCache(3)]
+            public long Calculate(int a, int b)
+            {
+                return a + b + DateTime.Now.Ticks;
+            }
+
+            [MemoryCache(3)]
             public Task<long> CalculateTask(int a, string b)
             {
                 return Task.FromResult(a + b.GetHashCode() + DateTime.Now.Ticks);
@@ -164,6 +170,17 @@ namespace Aspests.Tests
             a = 1;
             await target.DoTask(ref a);
             Assert.Equal(1, a);
+        }
+
+        [Fact]
+        public async Task Cache_Aspect_OppositeArguments()
+        {
+            var target = new TestClass();
+            var result1 = target.Calculate(20, 5);
+            await Task.Delay(10);
+            var result2 = target.Calculate(5, 20);
+
+            Assert.NotEqual(result1, result2);
         }
     }
 }

--- a/samples/tests/Aspests.Tests/CacheTests.cs
+++ b/samples/tests/Aspests.Tests/CacheTests.cs
@@ -30,6 +30,12 @@ namespace Aspests.Tests
                 return a + b.GetHashCode() + DateTime.Now.Ticks;
             }
 
+            [MemoryCache(3, true)]
+            public long CalculatePerInstance(int a, string b)
+            {
+                return a + b.GetHashCode() + DateTime.Now.Ticks;
+            }
+
             [MemoryCache(3)]
             public long Calculate(int a, int b)
             {
@@ -85,6 +91,18 @@ namespace Aspests.Tests
             var result2 = target2.Calculate(20, "test");
 
             Assert.Equal(result1, result2);
+        }
+
+        [Fact]
+        public async Task Cache_Aspect_Distinct_Instances_PerInstance()
+        {
+            var target = new TestClass();
+            var target2 = new TestClass();
+            var result1 = target.CalculatePerInstance(20, "test");
+            await Task.Delay(10);
+            var result2 = target2.CalculatePerInstance(20, "test");
+
+            Assert.NotEqual(result1, result2);
         }
 
         [Fact]


### PR DESCRIPTION
I've done a bit more than I suggested in https://github.com/pamidur/aspect-injector/issues/144, so here's the list of things I've done:

- I think suggestion with parameter of `PerInstance` is great! The only difference I made is that I believe default behavior should NOT be per instance. If you think it should be otherwise, it will be easy to change
- I've changed way of calculating hash of arguments. Previous way was incorrect, and if you had function accepting two same type arguments, their order didn't matter (see the test).
- `GetKey` now has two overloads - with and without instance. I also changed it to be `protected` instead `private`, so anyone can define their own way of creating a key, in they way they find suitable, by overriding these methods.
- Added tests for following changes
- Fixed some minor things, removed unused code, typos, renamed to match convention

I got a bit confused in line 58, because there are no tests for multiple triggers. So I figured I will use `Any` to define which key to use, but I'm not sure whether its correct.

I hope you like the changes :)