### PR TITLE
[Security] Update samples.yml to use actions/checkout@v2

### DIFF
--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest    
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 2.1.811


### PR DESCRIPTION
The workflow samples.yml is referencing action actions/checkout using references v1. 

However this reference is missing the commit a6747255bd19d7a757dbdda8c654a9f84db19839 which may contain fix to the some vulnerability.
The vulnerability fix that is missing by actions version could be related to:
(1) CVE fix
(2) upgrade of vulnerable dependency
(3) fix to secret leak and others.
Please consider to update the reference to the action.