### PR TITLE
Allow Aspects.Universal to work with generic return types

### DIFF
--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -11,6 +11,6 @@
     <None Include="$(MSBuildThisFileDirectory)../package.png" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AspectInjector" Version="2.6.0" PrivateAssets="None" />
+    <PackageReference Include="AspectInjector" Version="2.7.2" PrivateAssets="None" />
   </ItemGroup>
 </Project>

--- a/samples/src/Universal/Aspects/BaseUniversalWrapperAspect.cs
+++ b/samples/src/Universal/Aspects/BaseUniversalWrapperAspect.cs
@@ -15,7 +15,7 @@ namespace Aspects.Universal.Aspects
         private delegate object Wrapper(Func<object[], object> target, object[] args);
         private delegate object Handler(Func<object[], object> next, object[] args, AspectEventArgs eventArgs);
 
-        private static readonly Dictionary<MethodBase, Handler> _delegateCache = new Dictionary<MethodBase, Handler>();
+        private static readonly Dictionary<(MethodBase, Type), Handler> _delegateCache = new Dictionary<(MethodBase, Type), Handler>();
 
         private static readonly MethodInfo _asyncGenericHandler =
             typeof(BaseUniversalWrapperAttribute).GetMethod(nameof(BaseUniversalWrapperAttribute.WrapAsync), BindingFlags.NonPublic | BindingFlags.Instance);
@@ -93,13 +93,14 @@ namespace Aspects.Universal.Aspects
 
         private Handler GetMethodHandler(MethodBase method, Type returnType, IReadOnlyList<BaseUniversalWrapperAttribute> wrappers)
         {
-            if (!_delegateCache.TryGetValue(method, out var handler))
+            var key = (method, returnType);
+            if (!_delegateCache.TryGetValue(key, out var handler))
             {
                 lock (method)
                 {
-                    if (!_delegateCache.TryGetValue(method, out handler))
+                    if (!_delegateCache.TryGetValue(key, out handler))
                     {
-                        _delegateCache[method] = handler = CreateMethodHandler(method, returnType, wrappers);
+                        _delegateCache[key] = handler = CreateMethodHandler(method, returnType, wrappers);
                     }
                 }
             }


### PR DESCRIPTION
**Environment (please complete the following information):**
 - OS: Windows
 - Framework: net6.0
 - Type of application: console
 - Version of AspectInjector: 2.7.2

**Describe the bug**
An InvalidCastException is thrown when a method with a MethodAspect attribute and generic return type is called multiple times with different return type arguments.

**To Reproduce**
```csharp
public class LogCall : MethodAspectAttribute
{
    protected override void OnBefore(AspectEventArgs eventArgs)
        => Console.WriteLine($"OnBefore method {eventArgs.Name}");

    protected override void OnAfter(AspectEventArgs eventArgs)
        => Console.WriteLine($"OnAfter method {eventArgs.Name}");

    protected override T OnException<T>(AspectEventArgs eventArgs, Exception exception)
    {
        Console.WriteLine($"OnException method {eventArgs.Name} --> {exception}");
        throw exception;
    }
}

public class Program
{
    private static void Main()
    {
        try
        {   
            int n = Create<int>(); // OK
            bool b = Create<bool>(); // ERROR: invalid cast from bool to int
        }
        catch (Exception ex)
        {
            Console.WriteLine(ex);
        }
    }

    [LogCall]
    private static T Create<T>() where T : new() => new();
}
```

**Additional context**
The method handler cache in BaseUniversalWrapperAspect is using MethodBase objects as keys. Since the equality of these keys isn't affected by type arguments, every instantiation of a generic method ends up using the same handler. This leads to problems if any instantiations have different return types. Adding the return type to the cache's key ensures a different handler is built for each return type.